### PR TITLE
✏️ Fix typo `setMounth` to `setMonth` on date3 koan

### DIFF
--- a/www/koans/date3.html
+++ b/www/koans/date3.html
@@ -54,7 +54,7 @@
     <h1 id="koans-title">Datum und Uhrzeit ändern</h1>
     
     <div id="koans-lesson" class="paragraph">Passend zu den sieben Getter-Methoden besitzt das Date-Objekt sieben Setter-Methoden:
-<code>setFullYear</code>, <code>setMounth</code>, <code>setDate</code>, <code>setHours</code>, <code>setMinutes</code>,
+<code>setFullYear</code>, <code>setMonth</code>, <code>setDate</code>, <code>setHours</code>, <code>setMinutes</code>,
 <code>setSeconds</code> und <code>setMilliseconds</code>.
 Mit diesen 7 Methoden kann man den entsprechenden Date-Eintrag setzen:
 


### PR DESCRIPTION
Dieser PR behebt einen Rechtschreibfehler auf der [Datum und Uhrzeit ändern](https://www.jshero.net/koans/date3.html) Seite.

Für weitere Details siehe Issue.

Fixes: #40 