### PR TITLE
✏️ Fix typo `(Scheife)` to `(Schleife)` on roman1 koan

### DIFF
--- a/www/koans/roman1.html
+++ b/www/koans/roman1.html
@@ -53,7 +53,7 @@
 
     <h1 id="koans-title">Römische Zahlen I</h1>
     
-    <div id="koans-lesson" class="paragraph">Die folgende Aufgabe ist anspruchsvoll. Versuche eine iterative (Scheife) und eine rekursive Lösung zu finden.</div>
+    <div id="koans-lesson" class="paragraph">Die folgende Aufgabe ist anspruchsvoll. Versuche eine iterative (Schleife) und eine rekursive Lösung zu finden.</div>
     
     <h2>Aufgabe</h2>
     <div id="koans-task" class="paragraph">Schreibe eine Funktion <code>roman</code>, die eine


### PR DESCRIPTION
Dieser PR behebt einen Rechtschreibfehler auf der [Römische Zahlen I](https://www.jshero.net/koans/roman1.html) Seite.

Für weitere Details siehe Issue.

Fixes: #42 