### PR TITLE
✏️ Remove wrong semicolon in code example on method1 koan

### DIFF
--- a/www/koans/method1.html
+++ b/www/koans/method1.html
@@ -62,7 +62,7 @@ Methoden. Methoden operieren auf den Daten eines Objekts.
   preis: 2.15,
   erhoehePreis: function(erhoehung) {
     this.preis = this.preis + erhoehung;
-  };
+  }
 };
 
 var alterPreis = ware.preis;


### PR DESCRIPTION
Dieser PR behebt einen Rechtschreibfehler auf der [Methoden](https://www.jshero.net/koans/method1.html) Seite.

Für weitere Details siehe Issue.

Fixes: #44 